### PR TITLE
Return ok:true on _bulk_doc update

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -840,9 +840,9 @@ update_doc_result_to_json({{Id, Rev}, Error}) ->
 update_doc_result_to_json(#doc{id=DocId}, Result) ->
     update_doc_result_to_json(DocId, Result);
 update_doc_result_to_json(DocId, {ok, NewRev}) ->
-    {[{id, DocId}, {rev, couch_doc:rev_to_str(NewRev)}]};
+    {[{ok, true}, {id, DocId}, {rev, couch_doc:rev_to_str(NewRev)}]};
 update_doc_result_to_json(DocId, {accepted, NewRev}) ->
-    {[{id, DocId}, {rev, couch_doc:rev_to_str(NewRev)}, {accepted, true}]};
+    {[{ok, true}, {id, DocId}, {rev, couch_doc:rev_to_str(NewRev)}, {accepted, true}]};
 update_doc_result_to_json(DocId, Error) ->
     {_Code, ErrorStr, Reason} = chttpd:error_info(Error),
     {[{id, DocId}, {error, ErrorStr}, {reason, Reason}]}.

--- a/src/chttpd_test_util.erl
+++ b/src/chttpd_test_util.erl
@@ -1,0 +1,44 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_test_util).
+
+-export([start_couch/0, start_couch/1, stop_couch/0, stop_couch/1]).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+
+start_couch() ->
+    start_couch(?CONFIG_CHAIN).
+
+start_couch(IniFiles) ->
+    ok = application:set_env(config, ini_files, IniFiles),
+    ok = lager:start(),
+    ok = test_util:start_applications([inets, ibrowse, ssl, config, couch, chttpd]),
+    ok.
+
+
+stop_couch() ->
+    ok = application:stop(couch),
+    ok = application:stop(lager),
+    ok = application:stop(goldrush),
+    ok = application:stop(config),
+    ok = application:stop(ssl),
+    ok = application:stop(ibrowse),
+    ok = application:stop(inets),
+    ok = application:stop(chttpd),
+    ok.
+
+
+stop_couch(_) ->
+    stop_couch().
+

--- a/test/chttpd_db_test.erl
+++ b/test/chttpd_db_test.erl
@@ -1,0 +1,67 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_db_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+setup() ->
+    TmpDb = ?tempdb(),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    Url = lists:concat(["http://", Addr, ":", Port, "/", ?b2l(TmpDb)]),
+    create_db(Url),
+    Url.
+
+teardown(Url) ->
+    delete_db(Url).
+
+create_db(Url) ->
+    {ok, _, _, _} = test_request:put(Url,
+                [{"Content-Type", "application/json"}], "{}").
+
+delete_db(Url) ->
+    {ok, _, _, _} = test_request:delete(Url).
+
+all_test_() ->
+    {
+        "chttpd db tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_return_ok_true_on_bulk_update/1
+                ]
+            }
+        }
+    }.
+
+
+should_return_ok_true_on_bulk_update(Url) ->
+    ?_assertEqual(true,
+        begin
+            {ok, _, _, Body} = test_request:put(Url ++ "/testdoc",
+                [{"Content-Type", "application/json"}], "{}"),
+            {Json} = ?JSON_DECODE(Body),
+            Ref = couch_util:get_value(<<"rev">>, Json, undefined),
+            NewDoc = "{\"docs\": [{\"_rev\": \"" ++ ?b2l(Ref) ++ "\", \"_id\": \"testdoc\"}]}",
+            {ok, _, _, ResultBody} = test_request:post(Url ++ "/_bulk_docs/",
+                [{"Content-Type", "application/json"}], NewDoc),
+            ResultJson = ?JSON_DECODE(ResultBody),
+            {InnerJson} = lists:nth(1, ResultJson),
+            couch_util:get_value(<<"ok">>, InnerJson, undefined)
+        end).


### PR DESCRIPTION
Return `ok: true` on a successful _bulk_doc update like in
CouchDB 1.6.

Example success message on 2.0:
```
[{"id":"Brocket","rev":"6-b6fa9e703c3eb92aa9c3a49cedf1e8c2"}]
```

Example error message on 2.0:
```
[{"id":"Blaggie-System","error":"conflict",
  "reason":"Document update conflict."}]
```

Finally closes COUCHDB-2462