### PR TITLE
Convert {timeout, Error} errors to timeout

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -753,6 +753,8 @@ error_info(not_implemented) ->
 error_info(timeout) ->
     {500, <<"timeout">>, <<"The request could not be processed in a reasonable"
         " amount of time.">>};
+error_info({timeout, _Reason}) ->
+    error_info(timeout);
 error_info({Error, null}) ->
     error_info(Error);
 error_info({Error, Reason}) ->

--- a/test/chttpd_error_info_tests.erl
+++ b/test/chttpd_error_info_tests.erl
@@ -136,6 +136,12 @@ error_info_test() ->
                " amount of time.">>}
         },
         {
+            {timeout, Error},
+            {500, <<"timeout">>,
+             <<"The request could not be processed in a reasonable"
+               " amount of time.">>}
+        },
+        {
             {Error, null},
             {500, <<"unknown_error">>, Error}
         },


### PR DESCRIPTION
If chttpd got a {timeout, Error} error then it would return
that tuple to the client. Since Error is some internal specifics
this isn't particularly useful information to return to the client.

This commit converts it to our usual timeout response.

COUCHDB-2425