### PR TITLE
validate _all_docs query parameters

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -534,10 +534,11 @@ db_req(#httpd{path_parts=[_, DocId | FileNameParts]}=Req, Db) ->
 
 all_docs_view(Req, Db, Keys) ->
     Args0 = couch_mrview_http:parse_params(Req, Keys),
+    Args1 = couch_mrview_util:validate_args(Args0),
     ETagFun = fun(Sig, Acc0) ->
         couch_mrview_http:check_view_etag(Sig, Acc0, Req)
     end,
-    Args = Args0#mrargs{preflight_fun=ETagFun},
+    Args = Args1#mrargs{preflight_fun=ETagFun},
     Options = [{user_ctx, Req#httpd.user_ctx}],
     {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
         VAcc0 = #vacc{db=Db, req=Req},


### PR DESCRIPTION
Perform the same query parameter validation in the clustered interface for /_all_docs requests as we do in the non-clustered interface. Fixes COUCHDB-2523.