### PR TITLE
Set view type before validating _all_docs parameters

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -534,10 +534,12 @@ db_req(#httpd{path_parts=[_, DocId | FileNameParts]}=Req, Db) ->
 
 all_docs_view(Req, Db, Keys) ->
     Args0 = couch_mrview_http:parse_params(Req, Keys),
+    Args1 = Args0#mrargs{view_type=map},
+    Args2 = couch_mrview_util:validate_args(Args1),
     ETagFun = fun(Sig, Acc0) ->
         couch_mrview_http:check_view_etag(Sig, Acc0, Req)
     end,
-    Args = Args0#mrargs{preflight_fun=ETagFun},
+    Args = Args2#mrargs{preflight_fun=ETagFun},
     Options = [{user_ctx, Req#httpd.user_ctx}],
     {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
         VAcc0 = #vacc{db=Db, req=Req},


### PR DESCRIPTION
Matching couch_mrview, set view_type to "map" before validating query parameters for _all_docs. This fixes a bug whereby validation fails when specifying _all_docs?conflicts=true. I missed this in the previous fix for COUCHDB-2523.