### PR TITLE
Parse attachment-related parameters for /_changes

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -1336,6 +1336,12 @@ parse_changes_query(Req) ->
             Args#changes_args{include_docs=true};
         {"conflicts", "true"} ->
             Args#changes_args{conflicts=true};
+        {"attachments", "true"} ->
+            Options = [attachments | Args#changes_args.doc_options],
+            Args#changes_args{doc_options=Options};
+        {"att_encoding_info", "true"} ->
+            Options = [att_encoding_info | Args#changes_args.doc_options],
+            Args#changes_args{doc_options=Options};
         {"filter", _} ->
             Args#changes_args{filter=Value};
         {"seq_interval", _} ->


### PR DESCRIPTION
Match the way that couch_httpd_db:parse_changes_query handles attachment
related query parameters.

COUCHDB-2522