### PR TITLE
Remove _config route on cluster

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -364,7 +364,6 @@ url_handler("favicon.ico") ->   fun chttpd_misc:handle_favicon_req/1;
 url_handler("_utils") ->        fun chttpd_misc:handle_utils_dir_req/1;
 url_handler("_all_dbs") ->      fun chttpd_misc:handle_all_dbs_req/1;
 url_handler("_active_tasks") -> fun chttpd_misc:handle_task_status_req/1;
-url_handler("_config") ->       fun chttpd_misc:handle_config_req/1;
 url_handler("_reload_query_servers") -> fun chttpd_misc:handle_reload_query_servers_req/1;
 url_handler("_replicate") ->    fun chttpd_misc:handle_replicate_req/1;
 url_handler("_uuids") ->        fun chttpd_misc:handle_uuids_req/1;

--- a/src/chttpd_misc.erl
+++ b/src/chttpd_misc.erl
@@ -14,7 +14,6 @@
 
 -export([
     handle_all_dbs_req/1,
-    handle_config_req/1,
     handle_favicon_req/1,
     handle_favicon_req/2,
     handle_replicate_req/1,
@@ -232,58 +231,6 @@ handle_reload_query_servers_req(Req) ->
 handle_uuids_req(Req) ->
     couch_httpd_misc_handlers:handle_uuids_req(Req).
 
-
-% Config request handler
-
-
-% GET /_config/
-% GET /_config
-handle_config_req(#httpd{method='GET', path_parts=[_]}=Req) ->
-    Grouped = lists:foldl(fun({{Section, Key}, Value}, Acc) ->
-        case dict:is_key(Section, Acc) of
-        true ->
-            dict:append(Section, {list_to_binary(Key), list_to_binary(Value)}, Acc);
-        false ->
-            dict:store(Section, [{list_to_binary(Key), list_to_binary(Value)}], Acc)
-        end
-    end, dict:new(), config:all()),
-    KVs = dict:fold(fun(Section, Values, Acc) ->
-        [{list_to_binary(Section), {Values}} | Acc]
-    end, [], Grouped),
-    send_json(Req, 200, {KVs});
-% GET /_config/Section
-handle_config_req(#httpd{method='GET', path_parts=[_,Section]}=Req) ->
-    KVs = [{list_to_binary(Key), list_to_binary(Value)}
-            || {Key, Value} <- config:get(Section)],
-    send_json(Req, 200, {KVs});
-% PUT /_config/Section/Key
-% "value"
-handle_config_req(#httpd{method='PUT', path_parts=[_, Section, Key]}=Req) ->
-    Value = chttpd:json_body(Req),
-    Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
-    OldValue = config:get(Section, Key, ""),
-    ok = config:set(Section, Key, ?b2l(Value), Persist),
-    send_json(Req, 200, list_to_binary(OldValue));
-% GET /_config/Section/Key
-handle_config_req(#httpd{method='GET', path_parts=[_, Section, Key]}=Req) ->
-    case config:get(Section, Key, undefined) of
-    undefined ->
-        throw({not_found, unknown_config_value});
-    Value ->
-        send_json(Req, 200, list_to_binary(Value))
-    end;
-% DELETE /_config/Section/Key
-handle_config_req(#httpd{method='DELETE',path_parts=[_,Section,Key]}=Req) ->
-    Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
-    case config:get(Section, Key, undefined) of
-    undefined ->
-        throw({not_found, unknown_config_value});
-    OldValue ->
-        config:delete(Section, Key, Persist),
-        send_json(Req, 200, list_to_binary(OldValue))
-    end;
-handle_config_req(Req) ->
-    send_method_not_allowed(Req, "GET,PUT,DELETE").
 
 % Note: this resource is exposed on the backdoor interface, but it's in chttpd
 % because it's not couch trunk


### PR DESCRIPTION
In order to avoid users shooting themselves in the foot by using
`/_config/` on a clustered CouchDB with a loadbalancer in front,
we remove it on `15984` - it will be available for single-node-
mode on the backdoor port (`15986`) or for users that are feeling
lucky which want to fire curl requests to every node.

It also allows Fauxton to detect if it is running on a the backdoor
port. Fauxton will - if it gets a 200 instead of a 404 - show the
config-section to the user.

COUCHDB-2601 COUCHDB-2390 COUCHDB-2343