### PR TITLE
add _changes?feed=stream sugar for continuous

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -93,7 +93,7 @@ handle_changes_req1(#httpd{}=Req, Db) ->
             couch_stats:decrement_counter([couchdb, httpd, clients_requesting_changes])
         end;
     _ ->
-        Msg = <<"Supported `feed` types: normal, continuous, longpoll, eventsource">>,
+        Msg = <<"Supported `feed` types: normal, continuous, live, longpoll, eventsource">>,
         throw({bad_request, Msg})
     end.
 
@@ -1314,6 +1314,9 @@ parse_changes_query(Req) ->
     erlang:erase(changes_seq_interval),
     ChangesArgs = lists:foldl(fun({Key, Value}, Args) ->
         case {string:to_lower(Key), Value} of
+        {"feed", "live"} ->
+            %% sugar for continuous
+            Args#changes_args{feed="continuous"};
         {"feed", _} ->
             Args#changes_args{feed=Value};
         {"descending", "true"} ->


### PR DESCRIPTION
allow `feed=stream` as sugar for `continuous` which is hard to
type.

PRs for the change:
https://github.com/apache/couchdb/pull/307
https://github.com/apache/couchdb-couch/pull/40
https://github.com/apache/couchdb-chttpd/pull/28

closes COUCHDB-2237