### PR TITLE
Remove /_sleep endpoint

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -367,7 +367,6 @@ url_handler("_active_tasks") -> fun chttpd_misc:handle_task_status_req/1;
 url_handler("_reload_query_servers") -> fun chttpd_misc:handle_reload_query_servers_req/1;
 url_handler("_replicate") ->    fun chttpd_misc:handle_replicate_req/1;
 url_handler("_uuids") ->        fun chttpd_misc:handle_uuids_req/1;
-url_handler("_sleep") ->        fun chttpd_misc:handle_sleep_req/1;
 url_handler("_session") ->      fun chttpd_auth:handle_session_req/1;
 url_handler("_oauth") ->        fun couch_httpd_oauth:handle_oauth_req/1;
 url_handler("_up") ->           fun chttpd_misc:handle_up_req/1;

--- a/src/chttpd_misc.erl
+++ b/src/chttpd_misc.erl
@@ -18,7 +18,6 @@
     handle_favicon_req/2,
     handle_replicate_req/1,
     handle_reload_query_servers_req/1,
-    handle_sleep_req/1,
     handle_system_req/1,
     handle_task_status_req/1,
     handle_up_req/1,
@@ -90,13 +89,6 @@ maybe_add_csp_headers(Headers, "true") ->
     [{"Content-Security-Policy", Value} | Headers];
 maybe_add_csp_headers(Headers, _) ->
     Headers.
-
-handle_sleep_req(#httpd{method='GET'}=Req) ->
-    Time = list_to_integer(chttpd:qs_value(Req, "time")),
-    receive snicklefart -> ok after Time -> ok end,
-    send_json(Req, {[{ok, true}]});
-handle_sleep_req(Req) ->
-    send_method_not_allowed(Req, "GET,HEAD").
 
 handle_all_dbs_req(#httpd{method='GET'}=Req) ->
     Args = couch_mrview_http:parse_params(Req, undefined),


### PR DESCRIPTION
I was thought that only Windows command line needs a ping-sleep hack. Don't think we need this one.