### PR TITLE
Escape database name on posts to _replicate

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -305,7 +305,7 @@ fix_uri(Req, Props, Type) ->
         true ->
             Props;
         false ->
-            Uri = make_uri(Req,replication_uri(Type, Props)),
+            Uri = make_uri(Req, Uri0),
             [{Type,Uri}|proplists:delete(Type,Props)]
         end
     end.
@@ -315,8 +315,12 @@ replication_uri(Type, PostProps) ->
     {Props} ->
         couch_util:get_value(<<"url">>, Props);
     Else ->
-        Else
+        escape_dbname(Else)
     end.
+
+escape_dbname(DbName) ->
+    re:replace(DbName, "/", "%2f", [global, {return, binary}]).
+
 
 is_http(<<"http://", _/binary>>) ->
     true;

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -315,12 +315,8 @@ replication_uri(Type, PostProps) ->
     {Props} ->
         couch_util:get_value(<<"url">>, Props);
     Else ->
-        escape_dbname(Else)
+        iolist_to_binary(quote(Else))
     end.
-
-escape_dbname(DbName) ->
-    re:replace(DbName, "/", "%2f", [global, {return, binary}]).
-
 
 is_http(<<"http://", _/binary>>) ->
     true;

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -315,7 +315,7 @@ replication_uri(Type, PostProps) ->
     {Props} ->
         couch_util:get_value(<<"url">>, Props);
     Else ->
-        iolist_to_binary(quote_path(Else))
+        iolist_to_binary(quote(Else))
     end.
 
 is_http(<<"http://", _/binary>>) ->
@@ -485,9 +485,6 @@ unquote(UrlEncodedString) ->
 
 quote(UrlDecodedString) ->
     mochiweb_util:quote_plus(UrlDecodedString).
-
-quote_path(Path) ->
-    re:replace(Path, "/", "%2F", [global, {return, list}]).
 
 parse_form(#httpd{mochi_req=MochiReq}) ->
     mochiweb_multipart:parse_form(MochiReq).

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -315,7 +315,7 @@ replication_uri(Type, PostProps) ->
     {Props} ->
         couch_util:get_value(<<"url">>, Props);
     Else ->
-        iolist_to_binary(quote(Else))
+        iolist_to_binary(quote_path(Else))
     end.
 
 is_http(<<"http://", _/binary>>) ->
@@ -485,6 +485,9 @@ unquote(UrlEncodedString) ->
 
 quote(UrlDecodedString) ->
     mochiweb_util:quote_plus(UrlDecodedString).
+
+quote_path(Path) ->
+    re:replace(Path, "/", "%2F", [global, {return, list}]).
 
 parse_form(#httpd{mochi_req=MochiReq}) ->
     mochiweb_multipart:parse_form(MochiReq).

--- a/test/chttpd_handlers_test.erl
+++ b/test/chttpd_handlers_test.erl
@@ -1,0 +1,83 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_handlers_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+setup() ->
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    BaseUrl = lists:concat(["http://", Addr, ":", Port]),
+    BaseUrl.
+
+teardown(_Url) ->
+    ok.
+
+handlers_test_() ->
+    {
+        "chttpd handlers tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_escape_dbname_on_replicate/1
+                ]
+            }
+        }
+    }.
+
+should_escape_dbname_on_replicate(Url) ->
+    ?_test(
+        begin
+            Request = couch_util:json_encode({[
+                {<<"source">>, <<"foo/bar">>},
+                {<<"target">>, <<"bar/baz">>},
+                {<<"create_target">>, true}
+            ]}),
+            {ok, 200, _, Body} = request_replicate(Url ++ "/_replicate", Request),
+            JSON = couch_util:json_decode(Body),
+
+            Source = json_value(JSON, [<<"source">>, <<"url">>]),
+            Target = json_value(JSON, [<<"target">>, <<"url">>]),
+            ?assertEqual(<<"http://127.0.0.1:5984/foo%2Fbar">>, Source),
+            ?assertEqual(<<"http://127.0.0.1:5984/bar%2Fbaz">>, Target)
+        end).
+
+json_value(JSON, Keys) ->
+    couch_util:get_nested_json_value(JSON, Keys).
+
+
+request_replicate(Url, Body) ->
+    Headers = [{"Content-Type", "application/json"}],
+    Handler = {chttpd_misc, handle_replicate_req},
+    request(post, Url, Headers, Body, Handler, fun(Req) ->
+        chttpd:send_json(Req, 200, get(post_body))
+    end).
+
+request(Method, Url, Headers, Body, {M, F}, MockFun) ->
+    meck:new(M, [passthrough, non_strict]),
+    try
+        meck:expect(M, F, MockFun),
+        Result = test_request:Method(Url, Headers, Body),
+        ?assert(meck:validate(M)),
+        Result
+    catch Kind:Reason ->
+        {Kind, Reason}
+    after
+        meck:unload(M)
+    end.


### PR DESCRIPTION
Currently we convert local references of source/target specified in
JSON body into URLs.
This commit escapes database name. So slashes in name could be used.

COUCHDB-2666