### PR TITLE
Use an internal buffer to increase _changes throughput

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -34,6 +34,10 @@
     send_delayed_error/2, end_delayed_json_response/1,
     get_delayed_req/1]).
 
+-export([
+    chunked_response_buffer_size/0
+]).
+
 -record(delayed_resp, {
     start_fun,
     req,
@@ -994,3 +998,15 @@ stack_hash(Stack) ->
 
 with_default(undefined, Default) -> Default;
 with_default(Value, _) -> Value.
+
+%% @doc CouchDB uses a chunked transfer-encoding to stream responses to
+%% _all_docs, _changes, _view and other similar requests. This configuration
+%% value sets the maximum size of a chunk; the system will buffer rows in the
+%% response until it reaches this threshold and then send all the rows in one
+%% chunk to improve network efficiency. The default value is chosen so that
+%% the assembled chunk fits into the default Ethernet frame size (some reserved
+%% padding is necessary to accommodate the reporting of the chunk length). Set
+%% this value to 0 to restore the older behavior of sending each row in a
+%% dedicated chunk.
+chunked_response_buffer_size() ->
+    config:get_integer("httpd", "chunked_response_buffer", 1490).

--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -201,6 +201,10 @@ changes_callback({stop, EndSeq, Pending}, Acc) ->
     end,
     chttpd:end_delayed_json_response(Resp1);
 
+changes_callback(waiting_for_updates, Acc) ->
+    #cacc{buffer = Buf, mochi = Resp} = Acc,
+    {ok, Resp1} = chttpd:send_delayed_chunk(Resp, Buf),
+    {ok, Acc#cacc{buffer = [], bufsize = 0, mochi = Resp1}};
 changes_callback(timeout, Acc) ->
     {ok, Resp1} = chttpd:send_delayed_chunk(Acc#cacc.mochi, "\n"),
     {ok, Acc#cacc{mochi = Resp1}};

--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -604,7 +604,8 @@ all_docs_view(Req, Db, Keys, OP) ->
     Args = Args3#mrargs{preflight_fun=ETagFun},
     Options = [{user_ctx, Req#httpd.user_ctx}],
     {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
-        VAcc0 = #vacc{db=Db, req=Req},
+        Max = config:get_integer("httpd", "chunked_response_buffer", 1490),
+        VAcc0 = #vacc{db=Db, req=Req, threshold=Max},
         fabric:all_docs(Db, Options, fun couch_mrview_http:view_cb/2, VAcc0, Args)
     end),
     case is_record(Resp, vacc) of

--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -104,9 +104,6 @@ changes_callback(start, {"continuous", Req}) ->
 changes_callback({change, Change}, {"continuous", Resp}) ->
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, [?JSON_ENCODE(Change) | "\n"]),
     {ok, {"continuous", Resp1}};
-changes_callback({stop, EndSeq0}, {"continuous", Resp}) ->
-    % Temporary upgrade clause - Case 24236
-    changes_callback({stop, EndSeq0, null}, {"continuous", Resp});
 changes_callback({stop, EndSeq0, Pending}, {"continuous", Resp}) ->
     EndSeq = case is_old_couch(Resp) of true -> 0; false -> EndSeq0 end,
     Row = {[
@@ -153,9 +150,6 @@ changes_callback(start, {_, Req}) ->
 changes_callback({change, Change}, {Prepend, Resp}) ->
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, [Prepend, ?JSON_ENCODE(Change)]),
     {ok, {",\r\n", Resp1}};
-changes_callback({stop, EndSeq}, Acc) ->
-    % Temporary upgrade clause - Case 24236
-    changes_callback({stop, EndSeq, null}, Acc);
 changes_callback({stop, EndSeq, Pending}, {_, Resp}) ->
     {ok, Resp1} = case is_old_couch(Resp) of
     true ->

--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -86,8 +86,7 @@ handle_changes_req1(#httpd{}=Req, Db) ->
     ChangesArgs = Args0#changes_args{
         filter_fun = couch_changes:configure_filter(Raw, Style, Req, Db)
     },
-    % Default to ~filling the payload of a standard Ethernet frame
-    Max = config:get_integer("httpd", "chunked_response_buffer", 1490),
+    Max = chttpd:chunked_response_buffer_size(),
     case ChangesArgs#changes_args.feed of
     "normal" ->
         T0 = os:timestamp(),
@@ -604,7 +603,7 @@ all_docs_view(Req, Db, Keys, OP) ->
     Args = Args3#mrargs{preflight_fun=ETagFun},
     Options = [{user_ctx, Req#httpd.user_ctx}],
     {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
-        Max = config:get_integer("httpd", "chunked_response_buffer", 1490),
+        Max = chttpd:chunked_response_buffer_size(),
         VAcc0 = #vacc{db=Db, req=Req, threshold=Max},
         fabric:all_docs(Db, Options, fun couch_mrview_http:view_cb/2, VAcc0, Args)
     end),

--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -53,7 +53,8 @@ design_doc_view(Req, Db, DDoc, ViewName, Keys) ->
     end,
     Args = Args0#mrargs{preflight_fun=ETagFun},
     {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
-        VAcc0 = #vacc{db=Db, req=Req},
+        Max = config:get_integer("httpd", "chunked_response_buffer", 1490),
+        VAcc0 = #vacc{db=Db, req=Req, threshold=Max},
         fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, VAcc0, Args)
     end),
     case is_record(Resp, vacc) of

--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -53,7 +53,7 @@ design_doc_view(Req, Db, DDoc, ViewName, Keys) ->
     end,
     Args = Args0#mrargs{preflight_fun=ETagFun},
     {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
-        Max = config:get_integer("httpd", "chunked_response_buffer", 1490),
+        Max = chttpd:chunked_response_buffer_size(),
         VAcc0 = #vacc{db=Db, req=Req, threshold=Max},
         fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, VAcc0, Args)
     end),


### PR DESCRIPTION
This set of commits refactors the `changes_callback` function to keep an internal data buffer and flush it out the socket after a configurable number of bytes have been accumulated. It also adds support for a new callback message that will cause it to flush the buffer at the end of each traversal of the sequence tree for "live" feeds.

COUCHDB-2724
