### PR TITLE
Read request body on POST to changes feed

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -63,7 +63,8 @@ handle_request(#httpd{path_parts=[DbName|RestParts],method=Method,
 
 handle_changes_req(#httpd{method='POST'}=Req, Db) ->
     couch_httpd:validate_ctype(Req, "application/json"),
-    handle_changes_req1(Req, Db);
+    ReqBody = chttpd:body(Req),
+    handle_changes_req1(Req#httpd{req_body=ReqBody}, Db);
 handle_changes_req(#httpd{method='GET'}=Req, Db) ->
     handle_changes_req1(Req, Db);
 handle_changes_req(#httpd{path_parts=[_,<<"_changes">>]}=Req, _Db) ->


### PR DESCRIPTION
Prevents to return https://github.com/apache/couchdb-couch/pull/68 error for every POST request.