### PR TITLE
Dynamic http endpoint handlers

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -144,7 +144,8 @@ handle_request(MochiReq0) ->
     % removed, but URL quoting left intact
     RawUri = MochiReq:get(raw_path),
     {"/" ++ Path, _, _} = mochiweb_util:urlsplit_path(RawUri),
-    {HandlerKey, _, _} = mochiweb_util:partition(Path, "/"),
+    {HandlerKeyStr, _, _} = mochiweb_util:partition(Path, "/"),
+    HandlerKey = ?l2b(HandlerKeyStr),
 
     Peer = MochiReq:get(peer),
     LogForClosedSocket = io_lib:format("mochiweb_recv_error for ~s - ~p ~s", [
@@ -190,9 +191,7 @@ handle_request(MochiReq0) ->
         mochi_req = MochiReq,
         method = Method,
         path_parts = [list_to_binary(chttpd:unquote(Part))
-                || Part <- string:tokens(Path, "/")],
-        db_url_handlers = db_url_handlers(),
-        design_url_handlers = design_url_handlers()
+                || Part <- string:tokens(Path, "/")]
     },
 
     % put small token on heap to keep requests synced to backend calls
@@ -208,7 +207,8 @@ handle_request(MochiReq0) ->
         not_preflight ->
             case authenticate_request(HttpReq, AuthenticationFuns) of
             #httpd{} = Req ->
-                HandlerFun = url_handler(HandlerKey),
+                HandlerFun = chttpd_handlers:url_handler(
+                    HandlerKey, fun chttpd_db:handle_request/1),
                 HandlerFun(chttpd_auth_request:authorize_request(possibly_hack(Req)));
             Response ->
                 Response
@@ -362,46 +362,6 @@ authenticate_request(Response, _AuthFuns) ->
 
 increment_method_stats(Method) ->
     couch_stats:increment_counter([couchdb, httpd_request_methods, Method]).
-
-url_handler("") ->              fun chttpd_misc:handle_welcome_req/1;
-url_handler("favicon.ico") ->   fun chttpd_misc:handle_favicon_req/1;
-url_handler("_utils") ->        fun chttpd_misc:handle_utils_dir_req/1;
-url_handler("_all_dbs") ->      fun chttpd_misc:handle_all_dbs_req/1;
-url_handler("_active_tasks") -> fun chttpd_misc:handle_task_status_req/1;
-url_handler("_node") ->         fun chttpd_misc:handle_node_req/1;
-url_handler("_reload_query_servers") -> fun chttpd_misc:handle_reload_query_servers_req/1;
-url_handler("_replicate") ->    fun chttpd_misc:handle_replicate_req/1;
-url_handler("_uuids") ->        fun chttpd_misc:handle_uuids_req/1;
-url_handler("_session") ->      fun chttpd_auth:handle_session_req/1;
-url_handler("_oauth") ->        fun couch_httpd_oauth:handle_oauth_req/1;
-url_handler("_up") ->           fun chttpd_misc:handle_up_req/1;
-url_handler("_membership") ->   fun mem3_httpd:handle_membership_req/1;
-url_handler("_db_updates") ->   fun global_changes_httpd:handle_global_changes_req/1;
-url_handler("_cluster_setup") -> fun setup_httpd:handle_setup_req/1;
-url_handler(_) ->               fun chttpd_db:handle_request/1.
-
-db_url_handlers() ->
-    [
-        {<<"_view_cleanup">>,   fun chttpd_db:handle_view_cleanup_req/2},
-        {<<"_compact">>,        fun chttpd_db:handle_compact_req/2},
-        {<<"_design">>,         fun chttpd_db:handle_design_req/2},
-        {<<"_temp_view">>,      fun chttpd_view:handle_temp_view_req/2},
-        {<<"_changes">>,        fun chttpd_db:handle_changes_req/2},
-        {<<"_shards">>,         fun mem3_httpd:handle_shards_req/2},
-        {<<"_index">>,          fun mango_httpd:handle_req/2},
-        {<<"_explain">>,        fun mango_httpd:handle_req/2},
-        {<<"_find">>,           fun mango_httpd:handle_req/2}
-    ].
-
-design_url_handlers() ->
-    [
-        {<<"_view">>,           fun chttpd_view:handle_view_req/3},
-        {<<"_show">>,           fun chttpd_show:handle_doc_show_req/3},
-        {<<"_list">>,           fun chttpd_show:handle_view_list_req/3},
-        {<<"_update">>,         fun chttpd_show:handle_doc_update_req/3},
-        {<<"_info">>,           fun chttpd_db:handle_design_info_req/3},
-        {<<"_rewrite">>,        fun chttpd_rewrite:handle_rewrite_req/3}
-    ].
 
 % Utilities
 

--- a/src/chttpd_handlers.erl
+++ b/src/chttpd_handlers.erl
@@ -1,0 +1,60 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License.  You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_handlers).
+
+-export([
+    provider/2,
+    url_handler/2,
+    db_handler/2,
+    design_handler/2
+]).
+
+-include_lib("couch/include/couch_db.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+provider(App, Module) ->
+    couch_epi_functions:childspec(chttpd_handlers_subscription,
+       App, chttpd_handlers, Module).
+
+url_handler(HandlerKey, DefaultFun) ->
+    case collect(url_handler, [HandlerKey]) of
+        [HandlerFun] -> HandlerFun;
+        [] -> DefaultFun
+    end.
+
+db_handler(HandlerKey, DefaultFun) ->
+    case collect(db_handler, [HandlerKey]) of
+        [HandlerFun] -> HandlerFun;
+        [] -> DefaultFun
+    end.
+
+design_handler(HandlerKey, DefaultFun) ->
+    case collect(design_handler, [HandlerKey]) of
+        [HandlerFun] -> HandlerFun;
+        [] -> DefaultFun
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+collect(Func, Args) ->
+    Results = do_apply(Func, Args, [ignore_providers]),
+    [HandlerFun || HandlerFun <- Results, HandlerFun /= no_match].
+
+do_apply(Func, Args, Opts) ->
+    Handle = couch_epi:get_handle(?MODULE),
+    couch_epi:apply(Handle, chttpd, Func, Args, Opts).

--- a/src/chttpd_httpd_handlers.erl
+++ b/src/chttpd_httpd_handlers.erl
@@ -1,0 +1,43 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License.  You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_httpd_handlers).
+
+-export([url_handler/1, db_handler/1, design_handler/1]).
+
+url_handler(<<>>)                  -> fun chttpd_misc:handle_welcome_req/1;
+url_handler(<<"favicon.ico">>)     -> fun chttpd_misc:handle_favicon_req/1;
+url_handler(<<"_utils">>)          -> fun chttpd_misc:handle_utils_dir_req/1;
+url_handler(<<"_all_dbs">>)        -> fun chttpd_misc:handle_all_dbs_req/1;
+url_handler(<<"_active_tasks">>)   -> fun chttpd_misc:handle_task_status_req/1;
+url_handler(<<"_node">>)           -> fun chttpd_misc:handle_node_req/1;
+url_handler(<<"_reload_query_servers">>) -> fun chttpd_misc:handle_reload_query_servers_req/1;
+url_handler(<<"_replicate">>)      -> fun chttpd_misc:handle_replicate_req/1;
+url_handler(<<"_uuids">>)          -> fun chttpd_misc:handle_uuids_req/1;
+url_handler(<<"_session">>)        -> fun chttpd_auth:handle_session_req/1;
+url_handler(<<"_up">>)             -> fun chttpd_misc:handle_up_req/1;
+url_handler(_) -> no_match.
+
+db_handler(<<"_view_cleanup">>) -> fun chttpd_db:handle_view_cleanup_req/2;
+db_handler(<<"_compact">>)      -> fun chttpd_db:handle_compact_req/2;
+db_handler(<<"_design">>)       -> fun chttpd_db:handle_design_req/2;
+db_handler(<<"_temp_view">>)    -> fun chttpd_view:handle_temp_view_req/2;
+db_handler(<<"_changes">>)      -> fun chttpd_db:handle_changes_req/2;
+db_handler(_) -> no_match.
+
+design_handler(<<"_view">>)    -> fun chttpd_view:handle_view_req/3;
+design_handler(<<"_show">>)    -> fun chttpd_show:handle_doc_show_req/3;
+design_handler(<<"_list">>)    -> fun chttpd_show:handle_view_list_req/3;
+design_handler(<<"_update">>)  -> fun chttpd_show:handle_doc_update_req/3;
+design_handler(<<"_info">>)    -> fun chttpd_db:handle_design_info_req/3;
+design_handler(<<"_rewrite">>) -> fun chttpd_rewrite:handle_rewrite_req/3;
+design_handler(_) -> no_match.

--- a/src/chttpd_sup.erl
+++ b/src/chttpd_sup.erl
@@ -27,6 +27,7 @@ init([]) ->
     {ok, {{one_for_one, 3, 10}, [
         ?CHILD(chttpd, worker),
         ?CHILD(chttpd_auth_cache, worker),
+        chttpd_handlers:provider(chttpd, chttpd_httpd_handlers),
         {chttpd_auth_cache_lru,
 	 {ets_lru, start_link, [chttpd_auth_cache_lru, lru_opts()]},
 	 permanent, 5000, worker, [ets_lru]}


### PR DESCRIPTION
Use `couch_epi` to implement dynamic http endpoint handlers.

The application which wishes to add dynamic endpoint would
have to do following:

  1. Add a child into application supervisor

        chttpd_handler:registration_childspec(
            myapp, myapp_httpd_handlers)

  2. Provide `myapp_httpd_handlers` callback module

        -module(myapp_httpd_handlers).

        -export([url_handler/1, db_handler/1, design_handler/1]).

        url_handler(<<"_foo">>) -> fun myapp_httpd:handle_foo_req/1;
        url_handler(_) -> no_match.

        db_handler(<<"_bar">>) -> fun myapp_httpd:handle_bar_req/2;
        db_handler(_) -> no_match.

        design_handler(_) -> no_match.