### PR TITLE
Support endpoint overriding

### DIFF
--- a/src/chttpd_handlers.erl
+++ b/src/chttpd_handlers.erl
@@ -30,22 +30,13 @@ provider(App, Module) ->
        App, chttpd_handlers, Module).
 
 url_handler(HandlerKey, DefaultFun) ->
-    case collect(url_handler, [HandlerKey]) of
-        [HandlerFun] -> HandlerFun;
-        [] -> DefaultFun
-    end.
+    select(collect(url_handler, [HandlerKey]), DefaultFun).
 
 db_handler(HandlerKey, DefaultFun) ->
-    case collect(db_handler, [HandlerKey]) of
-        [HandlerFun] -> HandlerFun;
-        [] -> DefaultFun
-    end.
+    select(collect(db_handler, [HandlerKey]), DefaultFun).
 
 design_handler(HandlerKey, DefaultFun) ->
-    case collect(design_handler, [HandlerKey]) of
-        [HandlerFun] -> HandlerFun;
-        [] -> DefaultFun
-    end.
+    select(collect(design_handler, [HandlerKey]), DefaultFun).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
@@ -58,3 +49,17 @@ collect(Func, Args) ->
 do_apply(Func, Args, Opts) ->
     Handle = couch_epi:get_handle(?MODULE),
     couch_epi:apply(Handle, chttpd, Func, Args, Opts).
+
+select([], Default) ->
+    Default;
+select([{default, OverrideDefault}], _Default) ->
+    OverrideDefault;
+select(Handlers, _Default) ->
+    select(Handlers).
+
+select([Handler]) ->
+    Handler;
+select([{override, Handler}|_]) ->
+    Handler;
+select([_Handler | Rest]) ->
+    select(Rest).


### PR DESCRIPTION
There are two kinds of overrides:
- overriding regular endpoint
- overriding default handler (such as chttpd_db:handle_request/1)

Therefore there are two distinct options for overriding.

    url_handler(<<"_all_dbs">>) ->
        {override, fun mymodule:handle_all_dbs_req/1};

    url_handler(_) ->
        {default, fun mymodule:handle_request/1};