### PR TITLE
check POST requests for valid json header

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -26,7 +26,8 @@
     start_response_length/4, send/2, start_json_response/2,
     start_json_response/3, end_json_response/1, send_response/4,
     send_method_not_allowed/2, send_error/2, send_error/4, send_redirect/2,
-    send_chunked_error/2, send_json/2,send_json/3,send_json/4]).
+    send_chunked_error/2, send_json/2,send_json/3,send_json/4,
+    validate_ctype/2]).
 
 -export([authenticate_request/3]).
 
@@ -560,6 +561,9 @@ body(#httpd{mochi_req=MochiReq, req_body=ReqBody}) ->
         _Else ->
             ReqBody
     end.
+
+validate_ctype(Req, Ctype) ->
+    couch_httpd:validate_ctype(Req, Ctype).
 
 json_body(Httpd) ->
     case body(Httpd) of

--- a/src/chttpd_misc.erl
+++ b/src/chttpd_misc.erl
@@ -140,7 +140,7 @@ handle_task_status_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
 handle_replicate_req(#httpd{method='POST', user_ctx=Ctx} = Req) ->
-    couch_httpd:validate_ctype(Req, "application/json"),
+    chttpd:validate_ctype(Req, "application/json"),
     %% see HACK in chttpd.erl about replication
     PostBody = get(post_body),
     try replicate(PostBody, Ctx) of
@@ -216,6 +216,7 @@ choose_node(Key) ->
     choose_node(term_to_binary(Key)).
 
 handle_reload_query_servers_req(#httpd{method='POST'}=Req) ->
+    chttpd:validate_ctype(Req, "application/json"),
     ok = couch_proc_manager:reload(),
     send_json(Req, 200, {[{ok, true}]});
 handle_reload_query_servers_req(Req) ->

--- a/src/chttpd_show.erl
+++ b/src/chttpd_show.erl
@@ -169,6 +169,7 @@ handle_view_list_req(#httpd{method='GET'}=Req, _Db, _DDoc) ->
 
 handle_view_list_req(#httpd{method='POST',
         path_parts=[_, _, DesignName, _, ListName, ViewName]}=Req, Db, DDoc) ->
+    chttpd:validate_ctype(Req, "application/json"),
     ReqBody = chttpd:body(Req),
     {Props2} = ?JSON_DECODE(ReqBody),
     Keys = proplists:get_value(<<"keys">>, Props2, undefined),
@@ -177,6 +178,7 @@ handle_view_list_req(#httpd{method='POST',
 
 handle_view_list_req(#httpd{method='POST',
         path_parts=[_, _, _, _, ListName, DesignName, ViewName]}=Req, Db, DDoc) ->
+    chttpd:validate_ctype(Req, "application/json"),
     ReqBody = chttpd:body(Req),
     {Props2} = ?JSON_DECODE(ReqBody),
     Keys = proplists:get_value(<<"keys">>, Props2, undefined),

--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -70,6 +70,7 @@ handle_view_req(#httpd{method='GET',
 
 handle_view_req(#httpd{method='POST',
         path_parts=[_, _, _, _, ViewName]}=Req, Db, DDoc) ->
+    chttpd:validate_ctype(Req, "application/json"),
     Props = couch_httpd:json_body_obj(Req),
     Keys = couch_mrview_util:get_view_keys(Props),
     Queries = couch_mrview_util:get_view_queries(Props),


### PR DESCRIPTION
validate that all POST requests with json body must have also have valid
json header: {"Content-Type": "application/json"}
This ensures a basic protection against CSRF

JIRA: COUCHDB-2775