### PR TITLE
make _view_cleanup endpoint cluster aware

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -230,7 +230,7 @@ handle_compact_req(Req, _) ->
     couch_httpd:send_error(Req, 403, forbidden, Msg).
 
 handle_view_cleanup_req(Req, Db) ->
-    ok = fabric:cleanup_index_files(Db),
+    ok = fabric:cleanup_index_files_all_nodes(Db),
     send_json(Req, 202, {[{ok, true}]}).
 
 handle_design_req(#httpd{


### PR DESCRIPTION
Currently _view_cleanup endpoint is not cluster aware, only deletes
indexes on the node that gets the request. This will make it cluster
aware, deleting unused indexes on all nodes.

JIRA: COUCHDB-2779