### PR TITLE
POST to /{db}/_all_docs with invalid keys should return 400

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -818,6 +818,8 @@ error_info({error, {illegal_database_name, Name}}) ->
         "digits (0-9), and any of the characters _, $, (, ), +, -, and / ",
         "are allowed. Must begin with a letter.">>,
     {400, <<"illegal_database_name">>, Message};
+error_info({_DocID,{illegal_docid,DocID}}) ->
+    {400, <<"illegal_docid">>,DocID};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
 error_info(request_entity_too_large) ->

--- a/test/chttpd_error_info_tests.erl
+++ b/test/chttpd_error_info_tests.erl
@@ -116,6 +116,10 @@ error_info_test() ->
                " the characters _, $, (, ), +, -, and / are allowed."
                " Must begin with a letter.">>}
         },
+	{
+            {Error, {illegal_docid,1}},
+            {400, <<"illegal_docid">>, 1}
+	},
         {
             {missing_stub, Reason},
             {412, <<"missing_stub">>, Reason}


### PR DESCRIPTION
Now they return 500. Since there is nothing wrong on the server,
400 is more appropriate.

For example, turns requests like these:

http -a adm:pass POST http://127.0.0.1:15984/db1/_all_docs  keys:='["1",2]'
HTTP/1.1 500 Internal Server Error
Content-Type: application/json

{
    "error": "2",
    "reason": "{illegal_docid,2}"
}

Into:

http -a adm:pass POST http://127.0.0.1:15984/db1/_all_docs  keys:='["1",2]'
HTTP/1.1 400 Bad Request
Content-Type: application/json

{
    "error": "illegal_docid",
    "reason": 2
}

COUCHDB-2815