### PR TITLE
Handle bad replicate request

### DIFF
--- a/src/chttpd_misc.erl
+++ b/src/chttpd_misc.erl
@@ -156,6 +156,8 @@ handle_replicate_req(#httpd{method='POST', user_ctx=Ctx} = Req) ->
         send_json(Req, 500, {[{error, Type}, {reason, Details}]});
     {error, not_found} ->
         send_json(Req, 404, {[{error, not_found}]});
+    {bad_request, Reason} ->
+        send_json(Req, 400, {[{error, Reason}]});
     {error, Reason} ->
         try
             send_json(Req, 500, {[{error, Reason}]})


### PR DESCRIPTION
This patch is correctly handles https://github.com/apache/couchdb-couch-replicator/pull/12, and obsoletes https://github.com/cloudant/chttpd-local/pull/15

BugsID: 48602