### PR TITLE
Fix Last-Event-ID header handling for db changes feed

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -1435,7 +1435,7 @@ parse_changes_query(Req) ->
                 undefined ->
                     ChangesArgs;
                 Value ->
-                    ChangesArgs#changes_args{since=list_to_integer(Value)}
+                    ChangesArgs#changes_args{since=Value}
             end;
         _ ->
             ChangesArgs


### PR DESCRIPTION
This assumes Last-Event-ID header value to be opaque.

COUCHDB-2858