### PR TITLE
Don't set random ETag header for views

### DIFF
--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -24,41 +24,23 @@ multi_query_view(Req, Db, DDoc, ViewName, Queries) ->
         QueryArg = couch_mrview_http:parse_params(Query, undefined, Args1),
         couch_mrview_util:validate_args(QueryArg)
     end, Queries),
-    {ok, Resp2} = couch_httpd:etag_maybe(Req, fun() ->
-        VAcc0 = #vacc{db=Db, req=Req, prepend="\r\n"},
-        %% TODO: proper calculation of etag
-        Etag = [$", couch_uuids:new(), $"],
-        Headers = [{"ETag", Etag}],
-        FirstChunk = "{\"results\":[",
-        {ok, Resp0} = chttpd:start_delayed_json_response(VAcc0#vacc.req, 200, Headers, FirstChunk),
-        VAcc1 = VAcc0#vacc{resp=Resp0, etag=Etag},
-        VAcc2 = lists:foldl(fun(Args, Acc0) ->
-            {ok, Acc1} = fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, Acc0, Args),
-            Acc1
-        end, VAcc1, ArgQueries),
-        {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
-        {ok, Resp2} = chttpd:end_delayed_json_response(Resp1),
-        {ok, VAcc2#vacc{resp=Resp2}}
-    end),
-    case is_record(Resp2, vacc) of
-        true -> {ok, Resp2#vacc.resp};
-        _ -> {ok, Resp2}
-    end.
+    VAcc0 = #vacc{db=Db, req=Req, prepend="\r\n"},
+    FirstChunk = "{\"results\":[",
+    {ok, Resp0} = chttpd:start_delayed_json_response(VAcc0#vacc.req, 200, [], FirstChunk),
+    VAcc1 = VAcc0#vacc{resp=Resp0},
+    VAcc2 = lists:foldl(fun(Args, Acc0) ->
+        {ok, Acc1} = fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, Acc0, Args),
+        Acc1
+    end, VAcc1, ArgQueries),
+    {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
+    chttpd:end_delayed_json_response(Resp1).
 
 
 design_doc_view(Req, Db, DDoc, ViewName, Keys) ->
     Args = couch_mrview_http:parse_params(Req, Keys),
-    %% TODO: proper calculation of etag
-    Etag = [$", couch_uuids:new(), $"],
-    {ok, Resp} = couch_httpd:etag_maybe(Req, fun() ->
-        Max = chttpd:chunked_response_buffer_size(),
-        VAcc0 = #vacc{db=Db, req=Req, threshold=Max, etag=Etag},
-        fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, VAcc0, Args)
-    end),
-    case is_record(Resp, vacc) of
-        true -> {ok, Resp#vacc.resp};
-        _ -> {ok, Resp}
-    end.
+    Max = chttpd:chunked_response_buffer_size(),
+    VAcc = #vacc{db=Db, req=Req, threshold=Max},
+    fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, VAcc, Args).
 
 handle_view_req(#httpd{method='GET',
         path_parts=[_, _, _, _, ViewName]}=Req, Db, DDoc) ->


### PR DESCRIPTION
This fixes the issue that by setting a random ETag header, we implicitly
promised that there's a chance of a cache hit where there was no chance.

For 2.0, we simply remove the random ETag without replacement, in order
to not accidentally cause useless cache bloat in clients.

Here's Robert Newson's idea for an implementation that should be no more
expensive than what we do today:

1) delay the response until we have heard from one shard of each range
2) from this, construct the etag (we can change the workers to return
   more information along with their first rows (if any))
3) send 304 if the etag matches the header

That is, we have to hear from one shard per range to form the view, so
we can build a useful etag from that.

COUCHDB-2859