### PR TITLE
Fix return types of responses to view requests

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -618,7 +618,8 @@ all_docs_view(Req, Db, Keys, OP) ->
     Options = [{user_ctx, Req#httpd.user_ctx}],
     Max = chttpd:chunked_response_buffer_size(),
     VAcc = #vacc{db=Db, req=Req, threshold=Max},
-    fabric:all_docs(Db, Options, fun couch_mrview_http:view_cb/2, VAcc, Args3).
+    {ok, Resp} = fabric:all_docs(Db, Options, fun couch_mrview_http:view_cb/2, VAcc, Args3),
+    {ok, Resp#vacc.resp}.
 
 db_doc_req(#httpd{method='DELETE'}=Req, Db, DocId) ->
     % check for the existence of the doc to handle the 404 case.

--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -33,14 +33,16 @@ multi_query_view(Req, Db, DDoc, ViewName, Queries) ->
         Acc1
     end, VAcc1, ArgQueries),
     {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
-    chttpd:end_delayed_json_response(Resp1).
+    {ok, Resp2} = chttpd:end_delayed_json_response(Resp1),
+    {ok, Resp2#vacc.resp}.
 
 
 design_doc_view(Req, Db, DDoc, ViewName, Keys) ->
     Args = couch_mrview_http:parse_params(Req, Keys),
     Max = chttpd:chunked_response_buffer_size(),
     VAcc = #vacc{db=Db, req=Req, threshold=Max},
-    fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, VAcc, Args).
+    {ok, Resp} = fabric:query_view(Db, DDoc, ViewName, fun couch_mrview_http:view_cb/2, VAcc, Args),
+    {ok, Resp#vacc.resp}.
 
 handle_view_req(#httpd{method='GET',
         path_parts=[_, _, _, _, ViewName]}=Req, Db, DDoc) ->


### PR DESCRIPTION
This fixes an issue that was introduced with 72258e2 and e5b1aee.

Background:

Although all things still seemed to work, each request to a view
generated an exception with the following stack trace:

```
exception error: undefined function vacc:get/2
  in function  chttpd:result/2 (src/chttpd.erl, line 297)
  in call from chttpd:handle_request_int/1 (src/chttpd.erl, line 276)
  in call from mochiweb_http:headers/6 (src/mochiweb_http.erl, line 122)
```