### PR TITLE
Handle errors from before_request/after_request

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -290,12 +290,11 @@ catch_error(HttpReq, exit, {mochiweb_recv_error, E}) ->
         peer = Peer,
         original_method = Method
     } = HttpReq,
-    LogForClosedSocket = io_lib:format("mochiweb_recv_error for ~s - ~p ~s", [
+    couch_log:notice("mochiweb_recv_error for ~s - ~p ~s - ~p", [
         Peer,
         Method,
-        MochiReq:get(raw_path)
-    ]),
-    couch_log:notice(LogForClosedSocket ++ " - ~p", [E]),
+        MochiReq:get(raw_path),
+        E]),
     exit(normal);
 catch_error(HttpReq, exit, {uri_too_long, _}) ->
     send_error(HttpReq, request_uri_too_long);

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -311,8 +311,6 @@ catch_error(HttpReq, Tag, Error) ->
     case {Tag, Error, Stack} of
         {exit, normal, [{mochiweb_request, send, _, _} | _]} ->
             exit(normal); % Client disconnect (R15+)
-        {exit, normal, [{mochiweb_request, send, _} | _]} ->
-            exit(normal); % Client disconnect (R14)
         _Else ->
             send_error(HttpReq, {Error, nil, Stack})
     end.


### PR DESCRIPTION
This refactoring fixes the handling of errors from before_request.
Unify how we deal with errors among before_request and handle_request.