### PR TITLE
1.x compat

### DIFF
--- a/src/chttpd_external.erl
+++ b/src/chttpd_external.erl
@@ -69,7 +69,7 @@ json_req_obj(#httpd{mochi_req=Req,
         Else -> Else
     end,
     ParsedForm = case Req:get_primary_header_value("content-type") of
-        "application/x-www-form-urlencoded" ++ _ when Method =:= 'POST' ->
+        "application/x-www-form-urlencoded" ++ _ when Method =:= 'POST' orelse Method =:= 'PUT' ->
             mochiweb_util:parse_qs(Body);
         _ ->
             []

--- a/src/chttpd_show.erl
+++ b/src/chttpd_show.erl
@@ -99,15 +99,16 @@ show_etag(#httpd{user_ctx=UserCtx}=Req, Doc, DDoc, More) ->
 %     send_method_not_allowed(Req, "POST,PUT,DELETE,ETC");
 
 handle_doc_update_req(#httpd{
-        path_parts=[_, _, _, _, UpdateName, DocId]
-    }=Req, Db, DDoc) ->
-    Doc = maybe_open_doc(Db, DocId),
-    send_doc_update_response(Req, Db, DDoc, UpdateName, Doc, DocId);
-
-handle_doc_update_req(#httpd{
         path_parts=[_, _, _, _, UpdateName]
     }=Req, Db, DDoc) ->
     send_doc_update_response(Req, Db, DDoc, UpdateName, nil, null);
+
+handle_doc_update_req(#httpd{
+        path_parts=[_, _, _, _, UpdateName | DocIdParts]
+    }=Req, Db, DDoc) ->
+    DocId = ?l2b(string:join([?b2l(P) || P <- DocIdParts], "/")),
+    Doc = maybe_open_doc(Db, DocId),
+    send_doc_update_response(Req, Db, DDoc, UpdateName, Doc, DocId);
 
 handle_doc_update_req(Req, _Db, _DDoc) ->
     chttpd:send_error(Req, 404, <<"update_error">>, <<"Invalid path.">>).


### PR DESCRIPTION
- fix form parsing for update functions and PUT requests (cc @kocolosk https://github.com/apache/couchdb-chttpd/commit/5845146dec0f66c1e8f2b629dde6a445ae16785b)
- allow update funs to run on docs with a slash in their id (https://github.com/apache/couchdb/blob/1.x.x/share/www/script/test/update_documents.js#L197)
