### PR TITLE
Add chttpd_plugin:before_response/4 hook

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -693,7 +693,7 @@ send_response(#httpd{}=Req0, Code0, Headers0, Body0) ->
     Headers1 = Headers0 ++ server_header() ++
 	[timing(), reqid() | couch_httpd_auth:cookie_auth_header(Req0, Headers0)],
 
-    {ok, {#httpd{mochi_req=MochiReq}=Req, Code, Headers, Body}} =
+    {ok, {#httpd{mochi_req=MochiReq}, Code, Headers, Body}} =
         chttpd_plugin:before_response(Req0, Code0, Headers1, Body0),
 
     couch_stats:increment_counter([couchdb, httpd_status_codes, Code]),

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -689,10 +689,14 @@ send_chunk(Resp, Data) ->
     Resp:write_chunk(Data),
     {ok, Resp}.
 
-send_response(#httpd{mochi_req=MochiReq}=Req, Code, Headers0, Body) ->
+send_response(#httpd{}=Req0, Code0, Headers0, Body0) ->
+    Headers1 = Headers0 ++ server_header() ++
+	[timing(), reqid() | couch_httpd_auth:cookie_auth_header(Req0, Headers0)],
+
+    {ok, {#httpd{mochi_req=MochiReq}=Req, Code, Headers, Body}} =
+        chttpd_plugin:before_response(Req0, Code0, Headers1, Body0),
+
     couch_stats:increment_counter([couchdb, httpd_status_codes, Code]),
-    Headers = Headers0 ++ server_header() ++
-	[timing(), reqid() | couch_httpd_auth:cookie_auth_header(Req, Headers0)],
     {ok, MochiReq:respond({Code, Headers, Body})}.
 
 

--- a/src/chttpd_plugin.erl
+++ b/src/chttpd_plugin.erl
@@ -15,7 +15,8 @@
 -export([
     before_request/1,
     after_request/2,
-    handle_error/1
+    handle_error/1,
+    before_response/4
 ]).
 
 -define(SERVICE_ID, chttpd).
@@ -37,6 +38,11 @@ after_request(HttpReq, Result) ->
 handle_error(Error) ->
     [Error1] = with_pipe(after_request, [Error]),
     Error1.
+
+before_response(HttpReq0, Code0, Headers0, Value0) ->
+    [HttpReq, Code, Headers, Value] =
+        with_pipe(before_response, [HttpReq0, Code0, Headers0, Value0]),
+    {ok, {HttpReq, Code, Headers, Value}}.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions


### PR DESCRIPTION
This hook is useful in following casses:

  - to inject vendor specific headers
  - to inject vendor keys into json objects returned to client
  - to override return code

This PR depends on:

 - https://github.com/apache/couchdb-couch/pull/133