### PR TITLE
Improve cors support

### DIFF
--- a/src/chttpd_cors.erl
+++ b/src/chttpd_cors.erl
@@ -279,7 +279,7 @@ get_cors_config(#httpd{cors_config = undefined}) ->
         undefined ->
             ?SUPPORTED_HEADERS;
         AllowHeaders0 ->
-            split_list(AllowHeaders0)
+            [to_lower(H) || H <- split_list(AllowHeaders0)]
     end,
     AllowMethods = case config:get("cors", "methods", undefined) of
         undefined ->
@@ -291,7 +291,7 @@ get_cors_config(#httpd{cors_config = undefined}) ->
         undefined ->
             ?COUCH_HEADERS;
         ExposedHeaders0 ->
-            split_list(ExposedHeaders0)
+            [to_lower(H) || H <- split_list(ExposedHeaders0)]
     end,
     Origins0 = binary_split_list(config:get("cors", "origins", [])),
     Origins = [{O, {[]}} || O <- Origins0],

--- a/src/chttpd_cors.erl
+++ b/src/chttpd_cors.erl
@@ -268,7 +268,7 @@ allow_credentials(Config, Origin) ->
 get_cors_config(#httpd{cors_config = undefined}) ->
     EnableCors = config:get("httpd", "enable_cors", "false") =:= "true",
     AllowCredentials = config:get("cors", "credentials", "false") =:= "true",
-    AllowHeaders = case config:get("cors", "methods", undefined) of
+    AllowHeaders = case config:get("cors", "headers", undefined) of
         undefined ->
             ?SUPPORTED_HEADERS;
         AllowHeaders0 ->

--- a/src/chttpd_cors.erl
+++ b/src/chttpd_cors.erl
@@ -110,6 +110,10 @@ handle_preflight_request(Req, Config, Origin) ->
         SupportedMethods = get_origin_config(Config, Origin,
                 <<"allow_methods">>, ?SUPPORTED_METHODS),
 
+        SupportedHeaders = get_origin_config(Config, Origin,
+                <<"allow_headers">>, ?SUPPORTED_HEADERS),
+
+
         %% get max age
         MaxAge = couch_util:get_value("max_age", Config, ?CORS_DEFAULT_MAX_AGE),
 
@@ -135,7 +139,7 @@ handle_preflight_request(Req, Config, Origin) ->
                         {Headers, RH}
                 end,
                 %% check if headers are supported
-                case ReqHeaders -- ?SUPPORTED_HEADERS of
+                case ReqHeaders -- SupportedHeaders of
                 [] ->
                     PreflightHeaders = PreflightHeaders0 ++
                                        [{"Access-Control-Allow-Headers",


### PR DESCRIPTION
This PR makes it possible to configure CORS to be able to use custom headers.
It mostly fixes already existing code. The only new addition is `exposed_headers` setting.

The supported configuration is via `default.ini`:
```ini
[cors]
headers = "content-type, accept-ranges, ..."
methods = "COPY, DELETE, ...."
exposed_headers = "extra, accept-ranges, etag, server, ..."
```