### PR TITLE
Use couch_tests applications for chttpd_plugin_tests

### DIFF
--- a/test/chttpd_plugin_tests.erl
+++ b/test/chttpd_plugin_tests.erl
@@ -43,16 +43,14 @@ data_subscriptions() -> [].
 processes() -> [].
 notify(_, _, _) -> ok.
 
-setup() ->
-    application:stop(couch_epi), % in case it's already running from other tests...
-    application:unload(couch_epi),
-    ok = application:load(couch_epi),
-    ok = application:set_env(couch_epi, plugins, [?MODULE]), % only this plugin
-    ok = application:start(couch_epi).
 
-teardown(_) ->
-    ok = application:stop(couch_epi),
-    ok = application:unload(couch_epi).
+setup() ->
+    couch_tests:setup([
+        couch_epi_dispatch:dispatch(chttpd, ?MODULE)
+    ], [], []).
+
+teardown(Ctx) ->
+    couch_tests:teardown(Ctx).
 
 before_request({true, Id}) -> [{true, [{before_request, Id}]}];
 before_request({false, Id}) -> [{false, Id}];

--- a/test/chttpd_plugin_tests.erl
+++ b/test/chttpd_plugin_tests.erl
@@ -47,7 +47,7 @@ notify(_, _, _) -> ok.
 setup() ->
     couch_tests:setup([
         couch_epi_dispatch:dispatch(chttpd, ?MODULE)
-    ], [], []).
+    ]).
 
 teardown(Ctx) ->
     couch_tests:teardown(Ctx).


### PR DESCRIPTION
This fixes the problem with chttpd_plugin_tests. Previously following would fail:
```
make eunit apps=chttpd tests=callback_test,error_info_test
```
In order to test this PR you would need to add https://github.com/apache/couchdb-erlang-tests/pull/1 as a dependency in `rebar.config.script`. You might need to add the app into `rel/reltool.config` as well.