### PR TITLE
Fix CORS max_age configuration parameter

### DIFF
--- a/src/chttpd_cors.erl
+++ b/src/chttpd_cors.erl
@@ -115,7 +115,8 @@ handle_preflight_request(Req, Config, Origin) ->
 
 
         %% get max age
-        MaxAge = couch_util:get_value("max_age", Config, ?CORS_DEFAULT_MAX_AGE),
+        MaxAge = couch_util:get_value(<<"max_age">>, Config,
+            ?CORS_DEFAULT_MAX_AGE),
 
         PreflightHeaders0 = maybe_add_credentials(Config, Origin, [
             {"Access-Control-Allow-Origin", binary_to_list(Origin)},
@@ -300,6 +301,7 @@ get_cors_config(#httpd{cors_config = undefined, mochi_req = MochiReq}) ->
         ExposedHeaders0 ->
             [to_lower(H) || H <- split_list(ExposedHeaders0)]
     end,
+    MaxAge = cors_config(Host, "max_age", ?CORS_DEFAULT_MAX_AGE),
     Origins0 = binary_split_list(cors_config(Host, "origins", [])),
     Origins = [{O, {[]}} || O <- Origins0],
     [
@@ -308,6 +310,7 @@ get_cors_config(#httpd{cors_config = undefined, mochi_req = MochiReq}) ->
         {<<"allow_methods">>, AllowMethods},
         {<<"allow_headers">>, AllowHeaders},
         {<<"exposed_headers">>, ExposedHeaders},
+        {<<"max_age">>, MaxAge},
         {<<"origins">>, {Origins}}
     ];
 get_cors_config(#httpd{cors_config = Config}) ->

--- a/test/chttpd_cors_test.erl
+++ b/test/chttpd_cors_test.erl
@@ -349,8 +349,6 @@ test_good_headers_preflight_request_with_custom_config_(OwnerConfig) ->
     ?assert(chttpd_cors:is_cors_enabled(OwnerConfig)),
     AllowMethods = couch_util:get_value(
         <<"allow_methods">>, OwnerConfig, ?SUPPORTED_METHODS),
-    AllowHeaders = couch_util:get_value(
-        <<"allow_headers">>, OwnerConfig, ?SUPPORTED_HEADERS),
     MaxAge = couch_util:get_value(
         <<"max_age">>, OwnerConfig, ?CORS_DEFAULT_MAX_AGE),
     {ok, Headers1} = chttpd_cors:maybe_handle_preflight_request(Req, OwnerConfig),


### PR DESCRIPTION
Header `"Access-Control-Max-Age"` used by a browser to define for how long to keep preflight request's response cached.

This fix makes this parameter configurable through config section `[cors]`, attribute `max_age`.
