### PR TITLE
Create md5 etag for _local docs

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -621,8 +621,8 @@ json_body_obj(Httpd) ->
     end.
 
 
-doc_etag(#doc{revs={Start, [DiskRev|_]}}) ->
-    "\"" ++ ?b2l(couch_doc:rev_to_str({Start, DiskRev})) ++ "\"".
+doc_etag(#doc{id=Id, body=Body, revs={Start, [DiskRev|_]}}) ->
+    couch_httpd:doc_etag(Id, Body, {Start, DiskRev}).
 
 make_etag(Term) ->
     <<SigInt:128/integer>> = couch_crypto:hash(md5, term_to_binary(Term)),


### PR DESCRIPTION
This makes a unique ETAG for _local docs, so that they are cached
correctly, and fetched again when the document changes.

fixes COUCHDB-2978
