### PR TITLE
Reject incorrectly encoded urls

### DIFF
--- a/include/chttpd.hrl
+++ b/include/chttpd.hrl
@@ -20,3 +20,9 @@
     should_log = true,
     reason
 }).
+
+-define(is_hex(C), (
+    (C >= $0 andalso C =< $9) orelse
+    (C >= $a andalso C =< $f) orelse
+    (C >= $A andalso C =< $F)
+)).


### PR DESCRIPTION
This makes chttpd to raise `400 Bad Request` error in case provided URL consist "%" character that not followed by two hex characters as required by RFC 2141.

Related issue: COUCHDB-2748