### PR TITLE
Add support for single_max_doc

### DIFF
--- a/include/chttpd.hrl
+++ b/include/chttpd.hrl
@@ -26,3 +26,6 @@
     (C >= $a andalso C =< $f) orelse
     (C >= $A andalso C =< $F)
 )).
+
+% For any PUT/POST request, max size will be 4 GB (semi-unlimited)
+-define(DEFAULT_RECV_BODY, 4294967296).

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -599,12 +599,9 @@ body_length(#httpd{mochi_req=MochiReq}) ->
 body(#httpd{mochi_req=MochiReq, req_body=ReqBody}) ->
     case ReqBody of
         undefined ->
-            % Maximum size of document PUT request body (4GB)
-            MaxSize = list_to_integer(
-                config:get("couchdb", "max_document_size", "4294967296")),
             Begin = os:timestamp(),
             try
-                MochiReq:recv_body(MaxSize)
+                MochiReq:recv_body(?DEFAULT_RECV_BODY)
             after
                 T = timer:now_diff(os:timestamp(), Begin) div 1000,
                 put(body_time, T)
@@ -858,9 +855,9 @@ error_info({error, {database_name_too_long, DbName}}) ->
         <<"At least one path segment of `", DbName/binary, "` is too long.">>};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
-error_info({single_doc_too_large, MaxSize}) ->
+error_info({request_entity_too_large, MaxSize}) ->
     SizeBin = list_to_binary(integer_to_list(MaxSize)),
-    {413, <<"too_large">>, <<"Document exceeded single_max_doc_size:",
+    {413, <<"too_large">>, <<"Document exceeded max_document_size:",
         SizeBin/binary>>};
 error_info(request_entity_too_large) ->
     {413, <<"too_large">>, <<"the request entity is too large">>};

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -858,6 +858,10 @@ error_info({error, {database_name_too_long, DbName}}) ->
         <<"At least one path segment of `", DbName/binary, "` is too long.">>};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
+error_info({single_doc_too_large, MaxSize}) ->
+    SizeBin = list_to_binary(integer_to_list(MaxSize)),
+    {413, <<"too_large">>, <<"Document exceeded single_max_doc_size:",
+        SizeBin/binary>>};
 error_info(request_entity_too_large) ->
     {413, <<"too_large">>, <<"the request entity is too large">>};
 error_info({error, security_migration_updates_disabled}) ->

--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -19,7 +19,7 @@
     db_req/2, couch_doc_open/4,handle_changes_req/2,
     update_doc_result_to_json/1, update_doc_result_to_json/2,
     handle_design_info_req/3, handle_view_cleanup_req/2,
-    update_doc/4, http_code_from_status/1]).
+    update_doc/4, http_code_from_status/1, maybe_verify_body_size/1]).
 
 -import(chttpd,
     [send_json/2,send_json/3,send_json/4,send_method_not_allowed/2,

--- a/src/chttpd_external.erl
+++ b/src/chttpd_external.erl
@@ -20,6 +20,7 @@
 -import(chttpd,[send_error/4]).
 
 -include_lib("couch/include/couch_db.hrl").
+-include_lib("chttpd/include/chttpd.hrl").
 
 % handle_external_req/2
 % for the old type of config usage:
@@ -93,8 +94,7 @@ json_req_obj_field(<<"headers">>, #httpd{mochi_req=Req}, _Db, _DocId) ->
     Hlist = mochiweb_headers:to_list(Headers),
     to_json_terms(Hlist);
 json_req_obj_field(<<"body">>, #httpd{req_body=undefined, mochi_req=Req}, _Db, _DocId) ->
-    MaxSize = config:get_integer("couchdb", "max_document_size", 4294967296),
-    Req:recv_body(MaxSize);
+    Req:recv_body(?DEFAULT_RECV_BODY);
 json_req_obj_field(<<"body">>, #httpd{req_body=Body}, _Db, _DocId) ->
     Body;
 json_req_obj_field(<<"peer">>, #httpd{mochi_req=Req}, _Db, _DocId) ->

--- a/src/chttpd_show.erl
+++ b/src/chttpd_show.erl
@@ -130,6 +130,7 @@ send_doc_update_response(Req, Db, DDoc, UpdateName, Doc, DocId) ->
                 Options = [{user_ctx, Req#httpd.user_ctx}, {w, W}]
             end,
             NewDoc = couch_doc:from_json_obj({NewJsonDoc}),
+            ok = chttpd_db:maybe_verify_body_size(NewDoc#doc.body),
             couch_doc:validate_docid(NewDoc#doc.id),
             {UpdateResult, NewRev} = fabric:update_doc(Db, NewDoc, Options),
             NewRevStr = couch_doc:rev_to_str(NewRev),

--- a/test/chttpd_db_doc_size_test.erl
+++ b/test/chttpd_db_doc_size_test.erl
@@ -22,7 +22,8 @@
 
 setup() ->
     ok = config:set("admins", ?USER, ?PASS, _Persist=false),
-    ok = config:set("couchdb", "single_max_doc_size", "50"),
+    ok = config:set("couchdb", "max_document_size", "50"),
+    ok = config:set("couchdb", "use_max_document_size", "true"),
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),
@@ -33,7 +34,8 @@ setup() ->
 teardown(Url) ->
     delete_db(Url),
     ok = config:delete("admins", ?USER, _Persist=false),
-    ok = config:delete("couchdb", "single_max_doc_size").
+    ok = config:delete("couchdb", "max_document_size"),
+    ok = config:delete("couchdb", "use_max_document_size").
 
 create_db(Url) ->
     {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),

--- a/test/chttpd_db_doc_size_test.erl
+++ b/test/chttpd_db_doc_size_test.erl
@@ -1,0 +1,96 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_db_doc_size_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(USER, "chttpd_db_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(CONTENT_JSON, {"Content-Type", "application/json"}).
+
+setup() ->
+    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    ok = config:set("couchdb", "single_max_doc_size", "50"),
+    TmpDb = ?tempdb(),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    Url = lists:concat(["http://", Addr, ":", Port, "/", ?b2l(TmpDb)]),
+    create_db(Url),
+    Url.
+
+teardown(Url) ->
+    delete_db(Url),
+    ok = config:delete("admins", ?USER, _Persist=false),
+    ok = config:delete("couchdb", "single_max_doc_size").
+
+create_db(Url) ->
+    {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+delete_db(Url) ->
+    {ok, 200, _, _} = test_request:delete(Url, [?AUTH]).
+
+all_test_() ->
+    {
+        "chttpd db single doc max size test",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun post_single_doc/1,
+                    fun put_single_doc/1,
+                    fun bulk_doc/1
+                ]
+            }
+        }
+    }.
+
+post_single_doc(Url) ->
+    ?_assertEqual({<<"error">>, <<"too_large">>},
+        begin
+            NewDoc = "{\"post_single_doc\": \"some_doc\",
+                \"_id\": \"testdoc\", \"should_be\" : \"too_large\"}",
+            {ok, _, _, ResultBody} = test_request:post(Url,
+                [?CONTENT_JSON, ?AUTH], NewDoc),
+            {ErrorMsg} = ?JSON_DECODE(ResultBody),
+            lists:nth(1, ErrorMsg)
+        end).
+
+put_single_doc(Url) ->
+    ?_assertEqual({<<"error">>, <<"too_large">>},
+        begin
+            NewDoc = "{\"post_single_doc\": \"some_doc\",
+                \"_id\": \"testdoc\", \"should_be\" : \"too_large\"}",
+            {ok, _, _, ResultBody} = test_request:put(Url ++ "/" ++ "testid",
+                [?CONTENT_JSON, ?AUTH], NewDoc),
+            {ErrorMsg} = ?JSON_DECODE(ResultBody),
+            lists:nth(1, ErrorMsg)
+        end).
+
+bulk_doc(Url) ->
+    NewDoc = "{\"docs\": [{\"doc1\": 1}, {\"errordoc\":
+        \"this_should_be_the_error_document\"}]}",
+    {ok, _, _, ResultBody} = test_request:post(Url ++ "/_bulk_docs/",
+        [?CONTENT_JSON, ?AUTH], NewDoc),
+    ResultJson = ?JSON_DECODE(ResultBody),
+    {InnerJson1} = lists:nth(1, ResultJson),
+    {InnerJson2} = lists:nth(2, ResultJson),
+    Error = couch_util:get_value(<<"error">>, InnerJson1),
+    Msg = couch_util:get_value(<<"error">>, InnerJson2),
+    ?_assertEqual(<<"too_large">>, Error),
+    ?_assertEqual(undefined, Msg).


### PR DESCRIPTION
Users have been complaining about performance issues as well as indexing timeout issues.  Some of these issues are due to large documents. Currently, our only limitation is the max_document_size parameter that is set to 64 MB. With this enhancement, the goal is to provider some finer grained control over single document sizes and provide some more error info. The max_document_size still takes precedence. The default max size for a single doc is 1 MB.

During bulk requests, when one of the documents exceeds the single_doc_max_size value, it will not be created/updated. The error message will simply be "too_large" for that document. Other documents under the limit will be created/updated normally.

COUCHDB-2992
