### PR TITLE
use shard suffix when generating _changes ETag

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -90,7 +90,8 @@ handle_changes_req1(#httpd{}=Req, Db) ->
     "normal" ->
         T0 = os:timestamp(),
         {ok, Info} = fabric:get_db_info(Db),
-        Etag = chttpd:make_etag(Info),
+        Suffix = mem3:shard_suffix(Db),
+        Etag = chttpd:make_etag({Info, Suffix}),
         DeltaT = timer:now_diff(os:timestamp(), T0) / 1000,
         couch_stats:update_histogram([couchdb, dbinfo], DeltaT),
         chttpd:etag_respond(Req, Etag, fun() ->


### PR DESCRIPTION
In CouchDB 2.0, instance_start_time is always 0.
This means that when generating ETag values derived
from the database info object, the same ETags can be
incorrectly deemed valid between different database
instances with the metadata.

To avoid this we can incorporate the unique shard
suffix for the database instance when generating
the current ETag value.

COUCHDB-3017