### PR TITLE
Don't expect #vacc as a response of end_delayed_json_response in multi_query_view

### DIFF
--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -33,8 +33,7 @@ multi_query_view(Req, Db, DDoc, ViewName, Queries) ->
         Acc1
     end, VAcc1, ArgQueries),
     {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
-    {ok, Resp2} = chttpd:end_delayed_json_response(Resp1),
-    {ok, Resp2#vacc.resp}.
+    chttpd:end_delayed_json_response(Resp1).
 
 
 design_doc_view(Req, Db, DDoc, ViewName, Keys) ->


### PR DESCRIPTION
When `multi_query_view` is calling `chttpd:end_delayed_json_response/1` it is passing it the response it received from query_view's `#vacc`, which means it'll get back a response record and not `#vacc`.

COUCHDB-3031