### PR TITLE
Return error 410 on temporary view request

### DIFF
--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -77,4 +77,4 @@ handle_view_req(Req, _Db, _DDoc) ->
 
 handle_temp_view_req(Req, _Db) ->
     Msg = <<"Temporary views are not supported in CouchDB">>,
-    chttpd:send_error(Req, 403, forbidden, Msg).
+    chttpd:send_error(Req, 410, gone, Msg).


### PR DESCRIPTION
The request for temporary view is currently returning "403 Forbidden" error, which is implying a permissions issue. Error "410 Gone" seems to fit better.