### PR TITLE
Don't try to decode params in multi_query_view

### DIFF
--- a/src/chttpd_view.erl
+++ b/src/chttpd_view.erl
@@ -21,7 +21,8 @@ multi_query_view(Req, Db, DDoc, ViewName, Queries) ->
     {ok, #mrst{views=Views}} = couch_mrview_util:ddoc_to_mrst(Db, DDoc),
     Args1 = couch_mrview_util:set_view_type(Args0, ViewName, Views),
     ArgQueries = lists:map(fun({Query}) ->
-        QueryArg = couch_mrview_http:parse_params(Query, undefined, Args1),
+        QueryArg = couch_mrview_http:parse_params(Query, undefined,
+            Args1, [decoded]),
         couch_mrview_util:validate_args(QueryArg)
     end, Queries),
     VAcc0 = #vacc{db=Db, req=Req, prepend="\r\n"},


### PR DESCRIPTION
Parameters in `multi_query_view` got decoded before parsing as part of reading POST's json body. This makes `parse_params` to skip double parsing and allows to use complex view keys in multi query payload.

COUCHDB-3031