### PR TITLE
Don't end changes feed listener on heartbeat

### DIFF
--- a/src/chttpd_auth_cache.erl
+++ b/src/chttpd_auth_cache.erl
@@ -157,8 +157,8 @@ changes_callback({change, {Change}}, _) ->
             ets_lru:remove(?CACHE, UserName)
     end,
     {ok, couch_util:get_value(seq, Change)};
-changes_callback(timeout, EndSeq) ->
-    exit({seq, EndSeq});
+changes_callback(timeout, Acc) ->
+    {ok, Acc};
 changes_callback({error, _}, EndSeq) ->
     exit({seq, EndSeq}).
 


### PR DESCRIPTION
There's no need to end and restart the changes feed listener on every
heartbeat, so don't do that.

COUCHDB-3054