### PR TITLE
Drop logging level for "no record of user %s"

### DIFF
--- a/src/chttpd_auth_cache.erl
+++ b/src/chttpd_auth_cache.erl
@@ -168,7 +168,7 @@ load_user_from_db(UserName) ->
 	    {Props} = couch_doc:to_json_obj(Doc, []),
 	    Props;
 	_Else ->
-	    couch_log:warning("no record of user ~s", [UserName]),
+	    couch_log:debug("no record of user ~s", [UserName]),
 	    nil
     catch error:database_does_not_exist ->
 	    nil


### PR DESCRIPTION
This warning is tripped primarily when an admin is defined in local.ini
and has no associated _users document. This can happen fairly often in
development and testing setups, meaning that every other line in the
logfile is "no record of user admin".

The right thing to do here might be to check if the currently defined
user is a local admin and only complain in that situation, but presently
chttpd only directly depends on couch_auth_cache and to do so would 
require unencapsulating how couch_auth_cache handles ini file defined
admin users vs. authentication database users, which feels wrong.

Change suggested by @janl in #couchdb-dev IRC.