### PR TITLE
Add max_document_size checking for multipart PUT requests

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -761,6 +761,7 @@ db_doc_req(#httpd{method='PUT', user_ctx=Ctx}=Req, Db, DocId) ->
     RespHeaders = [{"Location", Loc}],
     case couch_util:to_list(couch_httpd:header_value(Req, "Content-Type")) of
     ("multipart/related;" ++ _) = ContentType ->
+        couch_httpd:check_max_request_length(Req),
         couch_httpd_multipart:num_mp_writers(mem3:n(mem3:dbname(Db#db.name), DocId)),
         {ok, Doc0, WaitFun, Parser} = couch_doc:doc_from_multi_part_stream(ContentType,
                 fun() -> receive_request_data(Req) end),


### PR DESCRIPTION
Previously multipart/related PUT requests didn't check maximum request sizes.

This commit checks content-length and compares that with the maximum.

This means keeping the current "semantics" of max_document_size which actually
means "max request size". But this makes the check more efficient and can
be done earlier in request processing time.

PR depends on https://github.com/apache/couchdb-couch/pull/201 make sure to
merge that one first if accepted.

Jira: COUCHDB-3174