### PR TITLE
HTTP code 500 instead of 400 for invalid key during document creation

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -885,6 +885,8 @@ error_info({_DocID,{illegal_docid,DocID}}) ->
 error_info({error, {database_name_too_long, DbName}}) ->
     {400, <<"database_name_too_long">>,
         <<"At least one path segment of `", DbName/binary, "` is too long.">>};
+error_info({doc_validation, Reason}) ->
+    {400, <<"doc_validation">>, Reason};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
 error_info(request_entity_too_large) ->


### PR DESCRIPTION
The wrong status code is returned when creating or updating a document
with an invalid key.
Returns:
{u'reason': u'Bad special document member: _invalid_key', u'error':
u'doc_validation'}
HTTPError: 500 Server Error: Internal Server Error
Expected: 400 Bad Request error

COUCHDB-3222