### PR TITLE
Include user_ctx in db open options

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -83,7 +83,8 @@ handle_changes_req(#httpd{path_parts=[_,<<"_changes">>]}=Req, _Db) ->
 handle_changes_req1(#httpd{}=Req, Db) ->
     #changes_args{filter=Raw, style=Style} = Args0 = parse_changes_query(Req),
     ChangesArgs = Args0#changes_args{
-        filter_fun = couch_changes:configure_filter(Raw, Style, Req, Db)
+        filter_fun = couch_changes:configure_filter(Raw, Style, Req, Db),
+        db_open_options = [{user_ctx, Db#db.user_ctx}]
     },
     Max = chttpd:chunked_response_buffer_size(),
     case ChangesArgs#changes_args.feed of


### PR DESCRIPTION
Previously original `Db` record was kept on `filter_fun` tuple in `#changes_args` and passed to the filters. Now we are throwing it away and including `Db` record build in fabric, which has `user_ctx` stripped from it. As a result `UserCtx` object passed to the filter functions in ddoc is missing user's name and role.

The fix includes original `user_ctx` into db open parameters, so `Db` record build in fabric will have it properly set.

COUCHDB-3233